### PR TITLE
DOC: Add a passage about the principle behind the learning approach

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,16 @@
 
 			into their workflows to answer their scientific questions in a reproducible manner.
 			</p>
+            <p>
+            These lessons are designed following the evidence-based, proven pedagogical
+            training and live coding (learn-by-doing) teaching practices fostered by
+            <a href="https://carpentries.org/">The Carpentries</a>.
+            </p>
+            <p>
+            These lessons are part of the
+             <a href="https://carpentries.org/lesson-development/community-lessons/">Community Lessons</a>
+            hosted at <a href="https://carpentries-incubator.org/">The Carpentries Incubator</a>.
+            </p>
           </div>
 
           <article class="profile-menu" id="menu">


### PR DESCRIPTION
Add a passage about the principle behind the learning approach:
- Briefly describe the approach, and that it is based on the one employed by The Carpentries.
- Mention that they are part of the Carpentries Incubator so that lessons are linked with the overall Carpentries community-developed lessons ecosystem.

This allows to make it clear that this is not a lone effort whose contents cannot be revitalised.